### PR TITLE
Add option to select VAN line level (high or low) on init

### DIFF
--- a/esp32_arduino_van_monitor/esp32_arduino_van_monitor.ino
+++ b/esp32_arduino_van_monitor/esp32_arduino_van_monitor.ino
@@ -26,7 +26,7 @@ void setup()
     Serial.begin(500000);
     printf("ESP32 Arduino VAN bus monitor\n");
 
-    VAN_RX.Init(VAN_DATA_RX_RMT_CHANNEL, VAN_DATA_RX_PIN, VAN_DATA_RX_LED_INDICATOR_PIN);
+    VAN_RX.Init(VAN_DATA_RX_RMT_CHANNEL, VAN_DATA_RX_PIN, VAN_DATA_RX_LED_INDICATOR_PIN, VAN_LINE_LEVEL_HIGH);
 }
 
 void loop()

--- a/main/main.c
+++ b/main/main.c
@@ -57,7 +57,7 @@ void rmt_van_rx_receive_task(void *pvParameter)
 
 void app_main() {
     // initialize hardware
-    rmt_van_rx_channel_init(VAN_DATA_RX_RMT_CHANNEL, VAN_DATA_RX_PIN, VAN_DATA_RX_LED_INDICATOR_PIN);
+    rmt_van_rx_channel_init(VAN_DATA_RX_RMT_CHANNEL, VAN_DATA_RX_PIN, VAN_DATA_RX_LED_INDICATOR_PIN, RX_VAN_LINE_LEVEL_HIGH);
 
     // start receive task
     xTaskCreate(rmt_van_rx_receive_task, "rmt_van_rx_receive_task", 1024*2, NULL, 10, NULL);

--- a/src/esp32_arduino_rmt_van_rx.cpp
+++ b/src/esp32_arduino_rmt_van_rx.cpp
@@ -7,8 +7,6 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
-
-
 ESP32_RMT_VAN_RX::ESP32_RMT_VAN_RX()
 {
 }
@@ -23,12 +21,12 @@ void ESP32_RMT_VAN_RX::Receive(uint8_t *messageLength, uint8_t message[])
     rmt_van_rx_receive(messageLength, message);
 }
 
-void ESP32_RMT_VAN_RX::Init(uint8_t channel, uint8_t rxPin, uint8_t ledPin)
+void ESP32_RMT_VAN_RX::Init(uint8_t channel, uint8_t rxPin, uint8_t ledPin, VAN_LINE_LEVEL vanLineLevel)
 {
     _rxPin = rxPin;
     _ledPin = ledPin;
     _channel = channel;
-    rmt_van_rx_channel_init(channel, rxPin, ledPin);
+    rmt_van_rx_channel_init(channel, rxPin, ledPin, static_cast<RX_VAN_LINE_LEVEL>(vanLineLevel));
 }
 
 void ESP32_RMT_VAN_RX::Stop(uint8_t channel)

--- a/src/esp32_arduino_rmt_van_rx.h
+++ b/src/esp32_arduino_rmt_van_rx.h
@@ -13,6 +13,10 @@
     extern "C" {
     #endif
         /* Include C code here */
+        typedef enum {
+            VAN_LINE_LEVEL_LOW   = 0,
+            VAN_LINE_LEVEL_HIGH  = 1,
+        } VAN_LINE_LEVEL;
     #ifdef __cplusplus
     }
     #endif
@@ -29,7 +33,7 @@ public:
     ~ESP32_RMT_VAN_RX();
 
     void Receive(uint8_t *messageLength, uint8_t message[]);
-    void Init(uint8_t channel, uint8_t rxPin, uint8_t ledPin);
+    void Init(uint8_t channel, uint8_t rxPin, uint8_t ledPin, VAN_LINE_LEVEL vanLineLevel);
     void Stop(uint8_t channel);
     bool IsCrcOk(uint8_t vanMessage[], uint8_t vanMessageLength);
 };

--- a/src/esp32_rmt_van_rx.c
+++ b/src/esp32_rmt_van_rx.c
@@ -4,6 +4,7 @@
 volatile uint8_t _rmt_van_rx_ledPin;
 volatile uint8_t _rmt_van_rx_rxPin;
 volatile uint8_t _rmt_van_rx_channel;
+volatile RX_VAN_LINE_LEVEL _rmt_van_rx_van_line_level;
 
 /* Initialize LED */
 void rmt_van_rx_led_init(uint8_t ledPin)
@@ -40,6 +41,10 @@ uint8_t round_to_nearest(uint8_t numToRound, uint8_t multiple)
 bool rmt_van_rx_parse_byte(uint8_t level, uint32_t duration, uint8_t *bitCounter, uint8_t *tempByte, uint8_t *mask, uint8_t *finalByte)
 {
     bool result = false;
+    if (_rmt_van_rx_van_line_level == RX_VAN_LINE_LEVEL_LOW)
+    {
+        level = !level;
+    }
 
     // on the bus the time slices are a little off from the multiple of 8 microseconds, so we round it to the nearest multiple of 8 before dividing
     uint8_t countOfTimeSlices = round_to_nearest(duration, 8) / 8;
@@ -216,11 +221,12 @@ bool rmt_van_rx_is_crc_ok(uint8_t vanMessage[], uint8_t vanMessageLength)
 }
 
 /* Initialize RMT receive channel */
-void rmt_van_rx_channel_init(uint8_t channel, uint8_t rxPin, uint8_t ledPin)
+void rmt_van_rx_channel_init(uint8_t channel, uint8_t rxPin, uint8_t ledPin, RX_VAN_LINE_LEVEL vanLineLevel)
 {
     _rmt_van_rx_ledPin = ledPin;
     _rmt_van_rx_channel = channel;
     _rmt_van_rx_rxPin = rxPin;
+    _rmt_van_rx_van_line_level = vanLineLevel;
 
     rmt_van_rx_led_init(_rmt_van_rx_ledPin);
 

--- a/src/esp32_rmt_van_rx.h
+++ b/src/esp32_rmt_van_rx.h
@@ -15,8 +15,13 @@
     extern "C" {
     #endif
 
+    typedef enum {
+        RX_VAN_LINE_LEVEL_LOW   = 0,
+        RX_VAN_LINE_LEVEL_HIGH  = 1,
+    } RX_VAN_LINE_LEVEL;
+
     void rmt_van_rx_receive(uint8_t *messageLength, uint8_t message[]) ;
-    void rmt_van_rx_channel_init(uint8_t channel, uint8_t rxPin, uint8_t ledPin);
+    void rmt_van_rx_channel_init(uint8_t channel, uint8_t rxPin, uint8_t ledPin, RX_VAN_LINE_LEVEL vanLineLevel);
     void rmt_van_rx_channel_stop(uint8_t channel);
     bool rmt_van_rx_is_crc_ok(uint8_t vanMessage[], uint8_t vanMessageLength);
 

--- a/src/keywords.txt
+++ b/src/keywords.txt
@@ -20,3 +20,4 @@ IsCrcOk	KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
+VAN_LINE_LEVEL	LITERAL1

--- a/src/library.properties
+++ b/src/library.properties
@@ -1,5 +1,5 @@
 name=ESP32_RMT_VAN_RX
-version=0.2
+version=0.3
 author=Peter Pinter <pinterpeti@gmail.com>
 maintainer=Peter Pinter
 sentence=ESP32 RMT Peripheral VAN bus receiver Library


### PR DESCRIPTION
If you connect your hardware to the low level line of the VAN bus, now it is possible to set it from the Init() method